### PR TITLE
Explain how to build with plain ghc(js) or cabal

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,134 @@
+Hacking on reflex-todomvc
+=========================
+Prerequisites
+-------------
+
+A working ghcjs environment with reflex and reflex-todomvc in it. See the [Reflex
+Hacking
+instructions](https://github.com/ryantrinkle/try-reflex/blob/master/HACKING.md)
+on how to get one. 
+
+Reflex-todomvc can be built with ghc and ghcjs. There are two ways to do
+this: building with straighg ghcjs and ghc, or building with cabal. 
+
+The tradeoffs are: 
+
+- Building with cabal involves a little cost. Every time you switch from ghc to ghcjs
+and vice versa you have to rembember to run 'cabal --configure
+--<compiler>'.
+
+- Building with plain ghc and ghjcs may feel a bit strange when you're
+used to building with cabal.  On the upside, you can keep two shells with
+their respective nix configuration open and generate ghc and ghcjs
+versions as you wish. Probably keeping cabal configured for ghc, so you
+can use e.g. `cabal repl` to play with your code, and using plain ghcjs
+to see the application in a browser.
+
+Building with just ghcjs and ghc
+--------------------------------
+
+Assuming you have cloned [Try
+Reflex](https://github.com/ryantrinkle/try-reflex) and carried out the
+instructions in
+[Hacking](https://github.com/ryantrinkle/try-reflex/blob/master/HACKING.md),
+and are in the root of try-reflex. Start a ghcjs environment:
+
+```
+:~/dev/spikes/try-reflex$ ./work-on ghcjs reflex-todomvc
+If you have any trouble with this script, please submit an issue at
+https://github.com/ryantrinkle/try-reflex/issues
+
+[nix-shell:~/dev/spikes/try-reflex]$ cd reflex-todomvc/
+```
+
+Build with ghcjs. We have to specify the `src` directory where the TodoMVC
+library lives, while we build the Main module in `src-bin`. We also add
+a few options so `src-bin` only contains our source, not compiler output. 
+
+```
+[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ ghcjs -isrc --make
+-outputdir dist -o dist/main.jsexe src-bin/main.hs
+[2 of 2] Compiling Main             ( src-bin/main.hs, dist/Main.js_o )
+Linking dist/main.jsexe (Main,Reflex.TodoMVC)
+```
+
+Open `/dist/main.jsexe/index.html` with a webbrowser to see your
+program.
+
+For ghc the steps are virtually identical, except the output is
+`dist/main` instead of `dist/main.jsexe`. 
+
+```
+:~/dev/spikes/try-reflex$ ./work-on ghc reflex-todomvc
+If you have any trouble with this script, please submit an issue at
+https://github.com/ryantrinkle/try-reflex/issues
+
+[nix-shell:~/dev/spikes/try-reflex]$ cd reflex-todomvc/
+```
+
+Build with ghc. Like with ghcjs We have to specify the `src` directory. 
+
+```
+[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ ghc -isrc --make
+-outputdir dist -o dist/main src-bin/main.hs
+[2 of 2] Compiling Main             ( src-bin/main.hs, dist/Main.o )
+Linking dist/main ...
+```
+
+To see the application, just run `./dist/main`.
+
+Building with cabal
+-------------------
+The first step is the same as for plain ghc and ghcjs - start a nix
+shell. Then run `cabal configure --ghcjs` or `cabal configure --ghc`.
+Executables can then be found under dist. Each time you switch
+compilers, run `cabal configure`.
+
+Assuming you have cloned [Try
+Reflex](https://github.com/ryantrinkle/try-reflex) and carried out the
+instructions in
+[Hacking](https://github.com/ryantrinkle/try-reflex/blob/master/HACKING.md),
+and are in the root of try-reflex. Start a ghcjs environment:
+
+```
+./work-on ghcjs reflex-todomvc
+```
+
+You should see this prompt
+
+```
+[nix-shell:~/dev/spikes/try-reflex]$
+``` 
+
+Go into the reflex-todomvc directory, configure and build with ghcjs.
+
+```
+[nix-shell:~/dev/spikes/try-reflex]$ cd reflex-todomvc/
+
+[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ cabal configure
+--ghcjs
+Warning: The package list for 'hackage.haskell.org' is 42.0 days old.
+Run 'cabal update' to get the latest list of available packages.
+Resolving dependencies...
+Configuring reflex-todomvc-0.1...
+
+[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ cabal build
+Building reflex-todomvc-0.1...
+Preprocessing library reflex-todomvc-0.1...
+In-place registering reflex-todomvc-0.1...
+Preprocessing executable 'reflex-todomvc' for reflex-todomvc-0.1...
+[1 of 1] Compiling Main             ( src-bin/main.hs,
+dist/build/reflex-todomvc/reflex-todomvc-tmp/Main.js_dyn_o )
+Linking dist/build/reflex-todomvc/reflex-todomvc.jsexe (Main)
+```
+
+You can open `index.html` in
+`dist/build/reflex-todomvc/reflex-todomvc.jsexe` with a browser to see
+the application in action.
+
+Building with ghc is very similar. `cabal configure --ghc && cabal
+build`. The executable will be in
+`./dist/build/reflex-todomvc/reflex-todomvc`.
+
+
+

--- a/HACKING.md
+++ b/HACKING.md
@@ -34,11 +34,11 @@ instructions in
 and are in the root of try-reflex. Start a ghcjs environment:
 
 ```
-:~/dev/spikes/try-reflex$ ./work-on ghcjs reflex-todomvc
+:~/try-reflex$ ./work-on ghcjs reflex-todomvc
 If you have any trouble with this script, please submit an issue at
 https://github.com/ryantrinkle/try-reflex/issues
 
-[nix-shell:~/dev/spikes/try-reflex]$ cd reflex-todomvc/
+[nix-shell:~/try-reflex]$ cd reflex-todomvc/
 ```
 
 Build with ghcjs. We have to specify the `src` directory where the TodoMVC
@@ -46,7 +46,7 @@ library lives, while we build the Main module in `src-bin`. We also add
 a few options so `src-bin` only contains our source, not compiler output. 
 
 ```
-[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ ghcjs -isrc --make
+[nix-shell:~/try-reflex/reflex-todomvc]$ ghcjs -isrc --make
 -outputdir dist -o dist/main.jsexe src-bin/main.hs
 [2 of 2] Compiling Main             ( src-bin/main.hs, dist/Main.js_o )
 Linking dist/main.jsexe (Main,Reflex.TodoMVC)
@@ -59,17 +59,17 @@ For ghc the steps are virtually identical, except the output is
 `dist/main` instead of `dist/main.jsexe`. 
 
 ```
-:~/dev/spikes/try-reflex$ ./work-on ghc reflex-todomvc
+:~/try-reflex$ ./work-on ghc reflex-todomvc
 If you have any trouble with this script, please submit an issue at
 https://github.com/ryantrinkle/try-reflex/issues
 
-[nix-shell:~/dev/spikes/try-reflex]$ cd reflex-todomvc/
+[nix-shell:~/try-reflex]$ cd reflex-todomvc/
 ```
 
 Build with ghc. Like with ghcjs We have to specify the `src` directory. 
 
 ```
-[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ ghc -isrc --make
+[nix-shell:~/try-reflex/reflex-todomvc]$ ghc -isrc --make
 -outputdir dist -o dist/main src-bin/main.hs
 [2 of 2] Compiling Main             ( src-bin/main.hs, dist/Main.o )
 Linking dist/main ...
@@ -97,22 +97,22 @@ and are in the root of try-reflex. Start a ghcjs environment:
 You should see this prompt
 
 ```
-[nix-shell:~/dev/spikes/try-reflex]$
+[nix-shell:~/try-reflex]$
 ``` 
 
 Go into the reflex-todomvc directory, configure and build with ghcjs.
 
 ```
-[nix-shell:~/dev/spikes/try-reflex]$ cd reflex-todomvc/
+[nix-shell:~/try-reflex]$ cd reflex-todomvc/
 
-[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ cabal configure
+[nix-shell:~/try-reflex/reflex-todomvc]$ cabal configure
 --ghcjs
 Warning: The package list for 'hackage.haskell.org' is 42.0 days old.
 Run 'cabal update' to get the latest list of available packages.
 Resolving dependencies...
 Configuring reflex-todomvc-0.1...
 
-[nix-shell:~/dev/spikes/try-reflex/reflex-todomvc]$ cabal build
+[nix-shell:~/try-reflex/reflex-todomvc]$ cabal build
 Building reflex-todomvc-0.1...
 Preprocessing library reflex-todomvc-0.1...
 In-place registering reflex-todomvc-0.1...


### PR DESCRIPTION
Hi @ryantrinkle , Following up on my question from yesterday, turned your answer into a bit of documentation, with ghc(js) command modified to put (intermediate) compiler output outside src. I didn't use ghc without cabal or stack much before this.

I erred on the side of verbosity, I find as a reader some duplication with variations can be helpful in understanding how things work.
