### PR TITLE
Add stack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ hsenv.log
 .#*
 src/Main
 *.jsexe
+.stack-work
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,10 @@ resolver: lts-3.13
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-- ../reflex-dom
+- location:
+    git: git@github.com:ryantrinkle/reflex-dom.git
+    commit: f4dbdd799260bc203f7f5cdce18362cb896f6d57
+  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,44 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+compiler: ghcjs-0.2.0.20151029_ghc-7.10.2
+compiler-check: match-exact
+setup-info:
+  ghcjs:
+      source:
+            ghcjs-0.2.0.20151029_ghc-7.10.2:
+                    url: "https://github.com/nrolland/ghcjs/releases/download/v0.2.0.20151029/ghcjs-0.2.0.20151029.tar.gz"
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.13
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- ../reflex-dom
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- ghcjs-dom-0.2.3.0
+- ref-tf-0.4
+- reflex-0.3.2
+- these-0.6.1.0
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
This will add ability to do:

```
stack setup
```

to set up GHCJS and friends, and:

```
stack build
```

to build it. To run, use:

```
open $(stack path --local-install-root)/bin/reflex-todomvc.jsexe/index.html
```
