### PR TITLE
Remove all compiler warnings

### DIFF
--- a/src/Reflex/TodoMVC.hs
+++ b/src/Reflex/TodoMVC.hs
@@ -23,7 +23,6 @@ import GHCJS.DOM.Types (JSM)
 
 import Reflex
 import Reflex.Dom.Core
-import Data.Text.Encoding (encodeUtf8)
 
 --------------------------------------------------------------------------------
 -- Model
@@ -116,17 +115,19 @@ taskEntry
   => m (Event t Task)
 taskEntry = el "header" $ do
     -- Create the textbox; it will be cleared whenever the user presses enter
-    rec let newValueEntered = ffilter (keyCodeIs Enter . fromIntegral) (_textInput_keypress descriptionBox)
-        descriptionBox <- textInput $ def
-          & textInputConfig_setValue .~ fmap (const "") newValueEntered
-          & textInputConfig_attributes .~ constDyn (mconcat [ "class" =: "new-todo"
-                                                            , "placeholder" =: "What needs to be done?"
-                                                            , "name" =: "newTodo"
-                                                            ])
+    rec let newValueEntered = keypress Enter descriptionBox
+        descriptionBox <- inputElement $ def
+          & inputElementConfig_setValue .~ fmap (const "") newValueEntered
+          & inputElementConfig_elementConfig . elementConfig_initialAttributes .~
+              mconcat [ "class" =: "new-todo"
+                      , "placeholder" =: "What needs to be done?"
+                      , "name" =: "newTodo"
+                      , "type" =: "text"
+                      ]
     -- -- Request focus on this element when the widget is done being built
     -- schedulePostBuild $ liftIO $ focus $ _textInput_element descriptionBox
     let -- | Get the current value of the textbox whenever the user hits enter
-        newValue = tag (current $ _textInput_value descriptionBox) newValueEntered
+        newValue = tag (current $ value descriptionBox) newValueEntered
     -- -- Set focus when the user enters a new Task
     -- performEvent_ $ fmap (const $ liftIO $ focus $ _textInput_element descriptionBox) newValueEntered
     return $ fmap (\d -> Task d False) $ fmapMaybe stripDescription newValue

--- a/style.css
+++ b/style.css
@@ -124,15 +124,15 @@ body {
 #toggle-all + label {
 	width: 60px;
 	height: 66px;
-  display: inline-block;
+	display: inline-block;
 	position: absolute;
-  line-height: 66px;
-  text-align: center;
+	line-height: 66px;
+	text-align: center;
 	-webkit-transform: rotate(90deg);
 	transform: rotate(90deg);
 	font-size: 22px;
 	color: #e6e6e6;
-  z-index: 10;
+	z-index: 10;
 }
 
 #toggle-all:checked + label {

--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ body {
 	border-top: 1px solid #e6e6e6;
 }
 
-.toggle-all {
+#toggle-all {
 	width: 1px;
 	height: 1px;
 	border: none; /* Mobile Safari */
@@ -121,25 +121,21 @@ body {
 	bottom: 100%;
 }
 
-.toggle-all + label {
+#toggle-all + label {
 	width: 60px;
-	height: 34px;
-	font-size: 0;
+	height: 66px;
+  display: inline-block;
 	position: absolute;
-	top: -52px;
-	left: -13px;
+  line-height: 66px;
+  text-align: center;
 	-webkit-transform: rotate(90deg);
 	transform: rotate(90deg);
-}
-
-.toggle-all + label:before {
-	content: '❯';
 	font-size: 22px;
 	color: #e6e6e6;
-	padding: 10px 27px 10px 27px;
+  z-index: 10;
 }
 
-.toggle-all:checked + label:before {
+#toggle-all:checked + label {
 	color: #737373;
 }
 

--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ body {
 	border-top: 1px solid #e6e6e6;
 }
 
-#toggle-all {
+.toggle-all {
 	width: 1px;
 	height: 1px;
 	border: none; /* Mobile Safari */
@@ -121,21 +121,25 @@ body {
 	bottom: 100%;
 }
 
-#toggle-all + label {
+.toggle-all + label {
 	width: 60px;
-	height: 66px;
-	display: inline-block;
+	height: 34px;
+	font-size: 0;
 	position: absolute;
-	line-height: 66px;
-	text-align: center;
+	top: -52px;
+	left: -13px;
 	-webkit-transform: rotate(90deg);
 	transform: rotate(90deg);
-	font-size: 22px;
-	color: #e6e6e6;
-	z-index: 10;
 }
 
-#toggle-all:checked + label {
+.toggle-all + label:before {
+	content: '❯';
+	font-size: 22px;
+	color: #e6e6e6;
+	padding: 10px 27px 10px 27px;
+}
+
+.toggle-all:checked + label:before {
 	color: #737373;
 }
 


### PR DESCRIPTION
* Fixed all deprecation warnings

* ~~Fixed `toggle-all`, which is broken on `develop`, because:~~
  * ~~When there are no elements it is `selected`~~
  * ~~Clicking it does nothing (because the label `for` attribute should link to an `id`, not a `class`, and maybe because it was a pseudo-element?)~~
* ~~Extracted `toggle-all` to its own component, for clarity, and used it from inside the `header`, so we don't have to position it with negative margins~~